### PR TITLE
Implement pagination support for articles list

### DIFF
--- a/src/app/article/[articleId]/page.tsx
+++ b/src/app/article/[articleId]/page.tsx
@@ -70,7 +70,7 @@ export default function ArticlePage(props: {
             <div>
               <div className="flex items-center gap-3 mb-2">
                 <h1 className="text-2xl sm:text-3xl font-bold">
-                  {article.title || "記事"}
+                  {article.title || "まいにちほめる"}
                 </h1>
                 {article.timePeriod && (
                   <span className="bg-white/20 backdrop-blur-sm px-3 py-1 rounded-full text-sm font-medium">

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import { Pagination } from "@/lib/api";
+
+interface PaginationProps {
+  pagination: Pagination;
+  onPageChange: (page: number) => void;
+  onLimitChange: (limit: number) => void;
+}
+
+export default function PaginationComponent({ pagination, onPageChange, onLimitChange }: PaginationProps) {
+  const { currentPage, totalPages, hasNext, hasPrev, limit, totalCount } = pagination;
+
+  const generatePageNumbers = () => {
+    const pages = [];
+    const maxVisiblePages = 5;
+    
+    if (totalPages <= maxVisiblePages) {
+      for (let i = 1; i <= totalPages; i++) {
+        pages.push(i);
+      }
+    } else {
+      const start = Math.max(1, currentPage - 2);
+      const end = Math.min(totalPages, start + maxVisiblePages - 1);
+      
+      for (let i = start; i <= end; i++) {
+        pages.push(i);
+      }
+    }
+    
+    return pages;
+  };
+
+  if (totalPages <= 1) return null;
+
+  return (
+    <div className="flex flex-col sm:flex-row items-center justify-between gap-4 mt-8 p-6 bg-white rounded-2xl shadow-lg border border-blue-100">
+      {/* Per page selector */}
+      <div className="flex items-center gap-2 text-sm text-gray-600">
+        <span>表示件数:</span>
+        <select
+          value={limit}
+          onChange={(e) => onLimitChange(Number(e.target.value))}
+          className="border border-gray-300 rounded-lg px-3 py-1 text-gray-700 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+        >
+          <option value={10}>10件</option>
+          <option value={20}>20件</option>
+          <option value={50}>50件</option>
+          <option value={100}>100件</option>
+        </select>
+      </div>
+
+      {/* Page info */}
+      <div className="text-sm text-gray-600">
+        {totalCount}件中 {((currentPage - 1) * limit + 1)}-{Math.min(currentPage * limit, totalCount)}件を表示
+      </div>
+
+      {/* Page navigation */}
+      <div className="flex items-center gap-1">
+        {/* Previous button */}
+        <button
+          onClick={() => onPageChange(currentPage - 1)}
+          disabled={!hasPrev}
+          className={`px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
+            hasPrev
+              ? 'bg-blue-100 text-blue-700 hover:bg-blue-200'
+              : 'bg-gray-100 text-gray-400 cursor-not-allowed'
+          }`}
+        >
+          前へ
+        </button>
+
+        {/* Page numbers */}
+        {generatePageNumbers().map((page) => (
+          <button
+            key={page}
+            onClick={() => onPageChange(page)}
+            className={`px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
+              page === currentPage
+                ? 'bg-blue-600 text-white'
+                : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+            }`}
+          >
+            {page}
+          </button>
+        ))}
+
+        {/* Next button */}
+        <button
+          onClick={() => onPageChange(currentPage + 1)}
+          disabled={!hasNext}
+          className={`px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
+            hasNext
+              ? 'bg-blue-100 text-blue-700 hover:bg-blue-200'
+              : 'bg-gray-100 text-gray-400 cursor-not-allowed'
+          }`}
+        >
+          次へ
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -14,19 +14,48 @@ export interface Article {
   filename?: string;
 }
 
-export async function getArticles(): Promise<Article[]> {
+export interface Pagination {
+  currentPage: number;
+  limit: number;
+  totalCount: number;
+  totalPages: number;
+  hasNext: boolean;
+  hasPrev: boolean;
+}
+
+export interface ArticlesResponse {
+  articles: Article[];
+  pagination: Pagination;
+}
+
+export async function getArticles(limit?: number, page?: number): Promise<ArticlesResponse> {
   try {
-    const response = await fetch(`${API_BASE_URL}/articles`);
+    const params = new URLSearchParams();
+    if (limit) params.append('limit', limit.toString());
+    if (page) params.append('page', page.toString());
+    
+    const url = `${API_BASE_URL}/articles${params.toString() ? `?${params.toString()}` : ''}`;
+    const response = await fetch(url);
 
     if (!response.ok) {
       throw new Error(`HTTP ${response.status}: Failed to fetch articles`);
     }
 
     const data = await response.json();
-    return data.articles || [];
+    return data;
   } catch (error) {
-    // エラー時は空配列を返す
-    return [];
+    // エラー時はデフォルト値を返す
+    return {
+      articles: [],
+      pagination: {
+        currentPage: 1,
+        limit: 10,
+        totalCount: 0,
+        totalPages: 0,
+        hasNext: false,
+        hasPrev: false
+      }
+    };
   }
 }
 


### PR DESCRIPTION
- Add Pagination interface and ArticlesResponse type
- Update getArticles function to support limit and page parameters
- Create new Pagination component with page navigation and limit selector
- Update HomePage to handle pagination state and controls
- Fix article page title fallback from "記事" to "まいにちほめる"

🤖 Generated with [Claude Code](https://claude.ai/code)