### PR TITLE
Fix pagination not working on page navigation

### DIFF
--- a/src/app/api/articles/route.ts
+++ b/src/app/api/articles/route.ts
@@ -9,7 +9,17 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: "Server configuration error" }, { status: 500 });
     }
 
-    const response = await fetch(`${API_BASE_URL}/api/articles`, {
+    const { searchParams } = new URL(request.url);
+    const limit = searchParams.get('limit');
+    const page = searchParams.get('page');
+    
+    const params = new URLSearchParams();
+    if (limit) params.append('limit', limit);
+    if (page) params.append('page', page);
+    
+    const url = `${API_BASE_URL}/api/articles${params.toString() ? `?${params.toString()}` : ''}`;
+    
+    const response = await fetch(url, {
       headers: {
         'X-API-Key': API_KEY
       },


### PR DESCRIPTION
Fix the issue where selecting different pages in pagination was still showing page 1 content. The API route was not properly forwarding the limit and page query parameters to the backend API.

🤖 Generated with [Claude Code](https://claude.ai/code)