### PR TITLE
Fix article numbering and navigation issues

### DIFF
--- a/src/components/ArticleList.tsx
+++ b/src/components/ArticleList.tsx
@@ -6,15 +6,21 @@ import { useToken } from "@/hooks/useToken";
 
 interface ArticleListProps {
   articles: Article[];
+  currentPage?: number;
+  limit?: number;
 }
 
-export default function ArticleList({ articles }: ArticleListProps) {
+export default function ArticleList({ articles, currentPage = 1, limit = 10 }: ArticleListProps) {
   const token = useToken();
   
   return (
     <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
       {articles.map((article, index) => {
-        const linkUrl = `/article/${article.articleId}${token ? `?token=${token}` : ''}`;
+        const params = new URLSearchParams();
+        if (token) params.append('token', token);
+        if (currentPage > 1) params.append('page', currentPage.toString());
+        if (limit !== 10) params.append('limit', limit.toString());
+        const linkUrl = `/article/${article.articleId}${params.toString() ? `?${params.toString()}` : ''}`;
         
         return (
         <article key={article.articleId} className="group">
@@ -27,7 +33,7 @@ export default function ArticleList({ articles }: ArticleListProps) {
                   <div className="flex items-center justify-between mb-3">
                     <div className="flex items-center gap-2">
                       <span className="text-xs font-semibold bg-white/20 px-3 py-1 rounded-full backdrop-blur-sm">
-                        #{String(index + 1).padStart(2, '0')}
+                        #{String((currentPage - 1) * limit + index + 1).padStart(2, '0')}
                       </span>
                       {article.timePeriod && (
                         <span className="text-xs font-semibold bg-white/30 px-2 py-1 rounded-full backdrop-blur-sm">

--- a/src/components/BackLink.tsx
+++ b/src/components/BackLink.tsx
@@ -2,13 +2,28 @@
 
 import Link from "next/link";
 import { useToken } from "@/hooks/useToken";
+import { useSearchParams } from "next/navigation";
 
 export default function BackLink() {
   const token = useToken();
+  const searchParams = useSearchParams();
+  
+  const buildBackUrl = () => {
+    const params = new URLSearchParams();
+    if (token) params.append('token', token);
+    
+    const page = searchParams.get('page');
+    const limit = searchParams.get('limit');
+    
+    if (page && page !== '1') params.append('page', page);
+    if (limit && limit !== '10') params.append('limit', limit);
+    
+    return `/${params.toString() ? `?${params.toString()}` : ''}`;
+  };
   
   return (
     <Link 
-      href={`/${token ? `?token=${token}` : ''}`}
+      href={buildBackUrl()}
       className="inline-flex items-center text-blue-100 hover:text-white transition-colors"
     >
       <svg className="w-4 h-4 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">


### PR DESCRIPTION
- Fix article numbering to show global sequence numbers instead of resetting per page
- Implement page preservation when navigating from article detail back to list
- Add URL parameter sync for page and limit states
- Update ArticleList to accept currentPage and limit props for proper numbering
- Enhance BackLink to preserve page context from URL parameters

🤖 Generated with [Claude Code](https://claude.ai/code)